### PR TITLE
Improve object.getValues annotation

### DIFF
--- a/lib/object/object.d.ts
+++ b/lib/object/object.d.ts
@@ -276,7 +276,7 @@ export function getValueByKeys(obj: any, ...args: (string | number | ArrayLike<s
  * @return {!Array<V>} The values in the object/map/hash.
  * @template K,V
  */
-export function getValues<T>(obj: { [s: string]: T } | ArrayLike<T>): T[];
+export function getValues<T = unknown>(obj: Record<string, T> | ArrayLike<T> | object): T[];
 /**
  * @fileoverview Utilities for manipulating objects/maps/hashes.
  */

--- a/lib/object/object.d.ts
+++ b/lib/object/object.d.ts
@@ -276,7 +276,7 @@ export function getValueByKeys(obj: any, ...args: (string | number | ArrayLike<s
  * @return {!Array<V>} The values in the object/map/hash.
  * @template K,V
  */
-export function getValues<K, V>(obj: any): V[];
+export function getValues<T>(obj: { [s: string]: T } | ArrayLike<T>): T[];
 /**
  * @fileoverview Utilities for manipulating objects/maps/hashes.
  */


### PR DESCRIPTION
Type definitions are now identical to Object.values() (which isn't supported by IE11 btw, so we cannot deprecate this easily)